### PR TITLE
A cheap in implementation way to create log with filter by source context

### DIFF
--- a/Vostok.Logging.Abstractions.Tests/Extensions/FilterBySourceContextLogExtensions_Tests.cs
+++ b/Vostok.Logging.Abstractions.Tests/Extensions/FilterBySourceContextLogExtensions_Tests.cs
@@ -10,59 +10,67 @@ namespace Vostok.Logging.Abstractions.Tests.Extensions
     public class FilterBySourceContextLogExtensions_Tests
     {
         private ILog baseLog;
+
         private LogEvent @event;
-        private ILog forContextBaseLog;
         private string context;
+        private string differentContext;
 
         [SetUp]
         public void TestSetup()
         {
             baseLog = Substitute.For<ILog>();
-            forContextBaseLog = Substitute.For<ILog>();
-            baseLog.ForContext(Arg.Any<string>()).Returns(info => forContextBaseLog);
-            
+            baseLog.ForContext(Arg.Any<string>()).Returns(info => baseLog);
+
             @event = new LogEvent(LogLevel.Info, DateTimeOffset.Now, null);
             context = "TestContext";
+            differentContext = "DifferentContext";
         }
 
         [Test]
-        public void SelectEventsBySourceContext_should_return_a_log_that_select_events_with_context()
+        public void WithEventsSelectedBySourceContext_should_return_a_log_that_select_events_with_context()
         {
             var filterLog = baseLog.WithEventsSelectedBySourceContext(context);
-            
-            filterLog.ForContext(context).Log(@event);
 
-            forContextBaseLog.Received(1).Log(@event);
+            filterLog.ForContext(context).Log(@event);
+            filterLog.ForContext(context).ForContext(differentContext).Log(@event);
+            filterLog.ForContext(differentContext).ForContext(context).ForContext(differentContext).Log(@event);
+
+            baseLog.Received(3).Log(@event);
         }
 
         [Test]
-        public void SelectEventsBySourceContext_should_return_a_log_that_drop_events_without_context()
+        public void WithEventsSelectedBySourceContext_should_return_a_log_that_drop_events_without_context()
         {
             var filterLog = baseLog.WithEventsSelectedBySourceContext(context);
-            
-            filterLog.ForContext("DifferentContext").Log(@event);
 
-            forContextBaseLog.ReceivedCalls().Should().BeEmpty();
+            filterLog.Log(@event);
+            filterLog.ForContext(differentContext).Log(@event);
+
+            baseLog.Received(0).Log(@event);
         }
 
         [Test]
-        public void DropEventsBySourceContext_should_return_a_log_that_drop_events_with_context()
+        public void WithEventsDroppedBySourceContext_should_return_a_log_that_drop_events_with_context()
         {
             var filterLog = baseLog.WithEventsDroppedBySourceContext(context);
-            
+
             filterLog.ForContext(context).Log(@event);
+            filterLog.ForContext(context).ForContext(differentContext).Log(@event);
+            filterLog.ForContext(differentContext).ForContext(context).Log(@event);
 
-            forContextBaseLog.ReceivedCalls().Should().BeEmpty();
+            baseLog.Received(0).Log(@event);
         }
 
         [Test]
-        public void DropEventsBySourceContext_should_return_a_log_that_select_events_without_context()
+        public void WithEventsDroppedBySourceContext_should_return_a_log_that_select_events_without_context()
         {
             var filterLog = baseLog.WithEventsDroppedBySourceContext(context);
-            
-            filterLog.ForContext("DifferentContext").Log(@event);
 
-            forContextBaseLog.Received(1).Log(@event);
+            filterLog.Log(@event);
+            filterLog.ForContext(differentContext).Log(@event);
+            filterLog.ForContext(differentContext).ForContext("AnotherDifferentContext").Log(@event);
+
+            baseLog.Received(3).Log(@event);
         }
     }
 }

--- a/Vostok.Logging.Abstractions.Tests/Extensions/FilterBySourceContextLogExtensions_Tests.cs
+++ b/Vostok.Logging.Abstractions.Tests/Extensions/FilterBySourceContextLogExtensions_Tests.cs
@@ -1,0 +1,68 @@
+using System;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Vostok.Logging.Abstractions;
+
+namespace Vostok.Logging.Abstractions.Tests.Extensions
+{
+    [TestFixture]
+    public class FilterBySourceContextLogExtensions_Tests
+    {
+        private ILog baseLog;
+        private LogEvent @event;
+        private ILog forContextBaseLog;
+        private string context;
+
+        [SetUp]
+        public void TestSetup()
+        {
+            baseLog = Substitute.For<ILog>();
+            forContextBaseLog = Substitute.For<ILog>();
+            baseLog.ForContext(Arg.Any<string>()).Returns(info => forContextBaseLog);
+            
+            @event = new LogEvent(LogLevel.Info, DateTimeOffset.Now, null);
+            context = "TestContext";
+        }
+
+        [Test]
+        public void SelectEventsBySourceContext_should_return_a_log_that_select_events_with_context()
+        {
+            var filterLog = baseLog.WithEventsSelectedBySourceContext(context);
+            
+            filterLog.ForContext(context).Log(@event);
+
+            forContextBaseLog.Received(1).Log(@event);
+        }
+
+        [Test]
+        public void SelectEventsBySourceContext_should_return_a_log_that_drop_events_without_context()
+        {
+            var filterLog = baseLog.WithEventsSelectedBySourceContext(context);
+            
+            filterLog.ForContext("DifferentContext").Log(@event);
+
+            forContextBaseLog.ReceivedCalls().Should().BeEmpty();
+        }
+
+        [Test]
+        public void DropEventsBySourceContext_should_return_a_log_that_drop_events_with_context()
+        {
+            var filterLog = baseLog.WithEventsDroppedBySourceContext(context);
+            
+            filterLog.ForContext(context).Log(@event);
+
+            forContextBaseLog.ReceivedCalls().Should().BeEmpty();
+        }
+
+        [Test]
+        public void DropEventsBySourceContext_should_return_a_log_that_select_events_without_context()
+        {
+            var filterLog = baseLog.WithEventsDroppedBySourceContext(context);
+            
+            filterLog.ForContext("DifferentContext").Log(@event);
+
+            forContextBaseLog.Received(1).Log(@event);
+        }
+    }
+}

--- a/Vostok.Logging.Abstractions.Tests/Extensions/FilterBySourceContextLogExtensions_Tests.cs
+++ b/Vostok.Logging.Abstractions.Tests/Extensions/FilterBySourceContextLogExtensions_Tests.cs
@@ -1,8 +1,6 @@
 using System;
-using FluentAssertions;
 using NSubstitute;
 using NUnit.Framework;
-using Vostok.Logging.Abstractions;
 
 namespace Vostok.Logging.Abstractions.Tests.Extensions
 {
@@ -71,6 +69,36 @@ namespace Vostok.Logging.Abstractions.Tests.Extensions
             filterLog.ForContext(differentContext).ForContext("AnotherDifferentContext").Log(@event);
 
             baseLog.Received(3).Log(@event);
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(5)]
+        public void WithEventsSelectedBySourceContext_should_return_a_log_that_pass_context_value_down(int contextsCount)
+        {
+            var filterLog = baseLog.WithEventsSelectedBySourceContext(context);
+
+            TestForContextPassing(contextsCount, filterLog);
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(5)]
+        public void WithEventsDroppedBySourceContext_should_return_a_log_that_pass_context_value_down(int contextsCount)
+        {
+            var filterLog = baseLog.WithEventsDroppedBySourceContext(context);
+
+            TestForContextPassing(contextsCount, filterLog);
+        }
+
+        private void TestForContextPassing(int contextsCount, ILog filterLog)
+        {
+            for (var i = 0; i < contextsCount; i++)
+            {
+                filterLog = filterLog.ForContext(i.ToString());
+
+                baseLog.Received(1).ForContext(i.ToString());
+            }
         }
     }
 }

--- a/Vostok.Logging.Abstractions/Extensions/FilterBySourceContextLogExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/FilterBySourceContextLogExtensions.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Linq;
 using JetBrains.Annotations;
-using Vostok.Logging.Abstractions.Values;
 
 namespace Vostok.Logging.Abstractions
 {
@@ -16,7 +14,7 @@ namespace Vostok.Logging.Abstractions
         {
             return new SourceContextFilterLog(log, context, true);
         }
-        
+
         /// <summary>
         /// <para>Returns a wrapper log that only logs events made by log with context equal to the name of <typeparamref name="T"/> passed to <see cref="ILog.ForContext(string)"/></para>
         /// </summary>
@@ -34,7 +32,7 @@ namespace Vostok.Logging.Abstractions
         {
             return new SourceContextFilterLog(log, context, false);
         }
-        
+
         /// <summary>
         /// <para>Returns a wrapper log that drops events made by log with context equal to the name of <typeparamref name="T"/> passed to <see cref="ILog.ForContext(string)"/></para>
         /// </summary>
@@ -43,8 +41,8 @@ namespace Vostok.Logging.Abstractions
         {
             return WithEventsDroppedBySourceContext(log, typeof(T).Name);
         }
-        
-        public class SourceContextFilterLog : ILog
+
+        private class SourceContextFilterLog : ILog
         {
             private readonly ILog baseLog;
             private readonly string contextFilterValue;

--- a/Vostok.Logging.Abstractions/Extensions/FilterBySourceContextLogExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/FilterBySourceContextLogExtensions.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using JetBrains.Annotations;
+using Vostok.Logging.Abstractions.Values;
+
+namespace Vostok.Logging.Abstractions
+{
+     public static class FilterBySourceContextLogExtensions
+    {
+        public static ILog WithEventsSelectedBySourceContext(this ILog log, string context)
+        {
+            return new SourceContextFilterLog(log, context, true);
+        }
+
+        public static ILog WithEventsDroppedBySourceContext(this ILog log, string context)
+        {
+            return new SourceContextFilterLog(log, context, false);
+        }
+
+        public class SourceContextFilterLog : ILog
+        {
+            private readonly ILog baseLog;
+            private readonly string contextFilterValue;
+            private readonly bool filterAllowsEvent;
+
+            public SourceContextFilterLog([NotNull] ILog baseLog,
+                                          [CanBeNull] SourceContextValue sourceContextValue,
+                                          [NotNull] string contextFilterValue,
+                                          bool filterAllowsEvent)
+            {
+                this.baseLog = baseLog;
+                this.contextFilterValue = contextFilterValue;
+                this.filterAllowsEvent = filterAllowsEvent;
+                SourceContext = sourceContextValue;
+            }
+
+            public SourceContextFilterLog([NotNull] ILog baseLog,
+                                          [NotNull] string contextFilterValue,
+                                          bool filterAllowsEvent)
+                : this(baseLog, null, contextFilterValue, filterAllowsEvent)
+            {
+            }
+
+            [CanBeNull]
+            public SourceContextValue SourceContext { get; }
+
+            public void Log(LogEvent @event)
+            {
+                var matchFilter = SourceContext?.Contains(contextFilterValue) ?? false;
+                if (matchFilter == filterAllowsEvent)
+                {
+                    baseLog.Log(@event);
+                }
+            }
+
+            public bool IsEnabledFor(LogLevel level) => baseLog.IsEnabledFor(level);
+
+            public ILog ForContext(string context)
+            {
+                var baseLogForContext = baseLog.ForContext(context);
+                var newSourceContext = SourceContext + new SourceContextValue(context);
+                return new SourceContextFilterLog(baseLogForContext, newSourceContext, contextFilterValue, filterAllowsEvent);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR may be an answer for #4 
Every logger with this new filter has it's own copy of source context to filter by.

Things to consider/improve:

1. Log created by FilterBySourceContextLogExtensions ignores previously added context for baseLog. However you can create an instance of SourceContextFilterLog with explicitly specified SourceContext. I consider it is OK for the common use-case when configuration (like adding a filter) happens before any ForContext calls.
2. ForContext method creates new instance every time it is called. This is done to update context value of baseLog and keep things like SourceContext property immutable. But it can trigger GC more in cases of numerous usages. (not sure if it is actually a problem)
