### PR TITLE
Make log.ForContext<MyClass<MyArg>>() return log.ForContext("MyClass`…

### DIFF
--- a/Vostok.Logging.Abstractions.Tests/Extensions/LogContextExtensions_Tests.cs
+++ b/Vostok.Logging.Abstractions.Tests/Extensions/LogContextExtensions_Tests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Diagnostics;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Vostok.Logging.Abstractions.Tests.Extensions
+{
+    [TestFixture]
+    internal class LogContextExtensions_Tests
+    {
+        [Test]
+        public void ForContext_with_shortname_with_nonGeneric_should_use_shortname_as_sourceContext()
+        {
+            var baseLog = Substitute.For<ILog>();
+            baseLog.ForContext<NonGeneric>(useFullTypeName: false);
+            baseLog.Received().ForContext(nameof(NonGeneric));
+        }
+
+        [Test]
+        public void ForContext_with_fullname_with_nonGeneric_should_use_fullname_as_sourceContext()
+        {
+            var baseLog = Substitute.For<ILog>();
+            baseLog.ForContext<NonGeneric>(useFullTypeName: true);
+            baseLog.Received().ForContext(typeof(NonGeneric).FullName);
+        }
+
+        [Test]
+        public void ForContext_with_fullname_with_generic_should_use_fullname_as_sourceContext()
+        {
+            var baseLog = Substitute.For<ILog>();
+            baseLog.ForContext<Generic<NonGeneric>>(useFullTypeName: true);
+            baseLog.Received().ForContext(typeof(Generic<NonGeneric>).FullName);
+        }
+
+        [Test]
+        public void ForContext_with_shortname_with_generic_should_use_clear_shortname_as_sourceContext()
+        {
+            var baseLog = Substitute.For<ILog>();
+            baseLog.ForContext<Generic<NonGeneric>>(useFullTypeName: false);
+            baseLog.Received().ForContext($"{nameof(Generic<object>)}`{nameof(NonGeneric)}");
+        }
+
+        [Test]
+        public void ForContext_with_shortname_with_megaGeneric_should_use_clear_shortname_as_sourceContext()
+        {
+            var baseLog = Substitute.For<ILog>();
+            baseLog.ForContext<MegaGeneric<object, object, object, object, object, object, object, object, object, object>>(useFullTypeName: false);
+            baseLog.Received()
+                .ForContext(
+                    $"{nameof(MegaGeneric<object, object, object, object, object, object, object, object, object, object>)}" +
+                    $"`Object`Object`Object`Object`Object`Object`Object`Object`Object`Object");
+        }
+
+        [Test]
+        public void ForContext_with_shortname_with_nested_generic_should_use_clear_shortname_as_sourceContext()
+        {
+            var baseLog = Substitute.For<ILog>();
+            baseLog.ForContext<Generic<Generic<NonGeneric>>>(useFullTypeName: false);
+            baseLog.Received().ForContext($"{nameof(Generic<object>)}`{nameof(Generic<object>)}`{nameof(NonGeneric)}");
+        }
+
+        [TestFixture]
+        [Explicit]
+        public class PerfTests
+        {
+            [Test]
+            public void ForContext_static_generic_perf()
+            {
+                var baseLog = new SilentLog();
+                baseLog.ForContext<Generic<Generic<NonGeneric>>>();
+
+                const int count = 100_000_000;
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < count; i++)
+                    baseLog.ForContext<Generic<Generic<NonGeneric>>>();
+                sw.Stop();
+                Console.Out.WriteLine($"elapsed: {sw.ElapsedMilliseconds}; throughput: {(count * 1000L / sw.ElapsedMilliseconds)} per second");
+            }
+
+            [Test]
+            public void ForContext_static_nonGeneric_perf()
+            {
+                var baseLog = new SilentLog();
+                baseLog.ForContext<NonGeneric>();
+
+                const int count = 100_000_000;
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < count; i++)
+                    baseLog.ForContext<NonGeneric>();
+                sw.Stop();
+                Console.Out.WriteLine($"elapsed: {sw.ElapsedMilliseconds}; throughput: {(count * 1000L / sw.ElapsedMilliseconds)} per second");
+            }
+
+            [Test]
+            public void ForContext_dynamic_generic_perf()
+            {
+                var baseLog = new SilentLog();
+                baseLog.ForContext(typeof(Generic<Generic<NonGeneric>>));
+
+                const int count = 100_000;
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < count; i++)
+                    baseLog.ForContext(typeof(Generic<Generic<NonGeneric>>));
+                sw.Stop();
+                Console.Out.WriteLine($"elapsed: {sw.ElapsedMilliseconds}; throughput: {(count * 1000L / sw.ElapsedMilliseconds)} per second");
+            }
+
+            [Test]
+            public void ForContext_dynamic_nonGeneric_perf()
+            {
+                var baseLog = new SilentLog();
+                baseLog.ForContext(typeof(NonGeneric));
+
+                const int count = 1_000_000;
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < count; i++)
+                    baseLog.ForContext(typeof(NonGeneric));
+                sw.Stop();
+                Console.Out.WriteLine($"elapsed: {sw.ElapsedMilliseconds}; throughput: {(count * 1000L / sw.ElapsedMilliseconds)} per second");
+            }
+        }
+
+        private class NonGeneric
+        {
+        }
+
+        private class Generic<T>
+        {
+        }
+
+        private class MegaGeneric<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
+        {
+        }
+    }
+}

--- a/Vostok.Logging.Abstractions/Extensions/LogContextExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/LogContextExtensions.cs
@@ -22,16 +22,13 @@ namespace Vostok.Logging.Abstractions
         [Pure]
         public static ILog ForContext<T>([NotNull] this ILog log)
         {
-            return log.ForContext(Holder<T>.ShortTypeName);
+            return log.ForContext<T>(useFullTypeName: false);
         }
 
         [Pure]
         public static ILog ForContext<T>([NotNull] this ILog log, bool useFullTypeName)
         {
-            if (useFullTypeName)
-                return log.ForContext(typeof(T).FullName);
-
-            return log.ForContext<T>();
+            return log.ForContext(useFullTypeName ? typeof(T).FullName : Holder<T>.ShortTypeName);
         }
 
         private static string GetShortTypeName(Type type)

--- a/Vostok.Logging.Abstractions/Extensions/LogContextExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/LogContextExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Text;
 using JetBrains.Annotations;
 
 namespace Vostok.Logging.Abstractions
@@ -15,19 +16,44 @@ namespace Vostok.Logging.Abstractions
         [Pure]
         public static ILog ForContext([NotNull] this ILog log, [NotNull] Type type, bool useFullTypeName)
         {
-            return log.ForContext((useFullTypeName ? type.FullName : type.Name) ?? string.Empty);
+            return log.ForContext((useFullTypeName ? type.FullName : GetShortTypeName(type)) ?? string.Empty);
         }
 
         [Pure]
         public static ILog ForContext<T>([NotNull] this ILog log)
         {
-            return log.ForContext<T>(false);
+            return log.ForContext(Holder<T>.ShortTypeName);
         }
 
         [Pure]
         public static ILog ForContext<T>([NotNull] this ILog log, bool useFullTypeName)
         {
-            return log.ForContext(typeof(T), useFullTypeName);
+            if (useFullTypeName)
+                return log.ForContext(typeof(T).FullName);
+
+            return log.ForContext<T>();
+        }
+
+        private static string GetShortTypeName(Type type)
+        {
+            var typeName = type.Name;
+            if (!type.IsGenericType)
+                return typeName;
+
+            var result = new StringBuilder();
+            result.Append(typeName.Substring(0, typeName.LastIndexOf("`")));
+            foreach (var arg in type.GetGenericArguments())
+            {
+                result.Append('`');
+                result.Append(GetShortTypeName(arg));
+            }
+            
+            return result.ToString();
+        }
+
+        private class Holder<T>
+        {
+            public static readonly string ShortTypeName = GetShortTypeName(typeof(T));
         }
     }
 }


### PR DESCRIPTION
…MyArg") instead of log.ForContext("MyClass`1")