### PR TITLE
Allow dot char in property names

### DIFF
--- a/Vostok.Logging.Abstractions.Tests/Helpers/TemplatePropertiesExtractor_Tests.cs
+++ b/Vostok.Logging.Abstractions.Tests/Helpers/TemplatePropertiesExtractor_Tests.cs
@@ -19,6 +19,7 @@ namespace Vostok.Logging.Abstractions.Tests.Helpers
         [TestCase("{1}", "1")]
         [TestCase("{_prop}", "_prop")]
         [TestCase("{_PROP}", "_PROP")]
+        [TestCase("{.prop}", ".prop")]
 
         [TestCase("{prop:format}", "prop")]
         [TestCase("{0:format}", "0")]

--- a/Vostok.Logging.Abstractions/Helpers/TemplatePropertiesExtractor.cs
+++ b/Vostok.Logging.Abstractions/Helpers/TemplatePropertiesExtractor.cs
@@ -16,6 +16,7 @@ namespace Vostok.Logging.Abstractions.Helpers
         private const char Underscore = '_';
         private const char Whitespace = ' ';
         private const char Colon = ':';
+        private const char Dot = '.';
 
         private static readonly RecyclingBoundedCache<string, string[]> Cache
             = new RecyclingBoundedCache<string, string[]>(CacheCapacity, StringComparer.Ordinal);
@@ -150,7 +151,7 @@ namespace Vostok.Logging.Abstractions.Helpers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsValidInName(char c)
         {
-            return char.IsLetterOrDigit(c) || c == Underscore;
+            return char.IsLetterOrDigit(c) || c == Underscore || c == Dot;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
This allows the dot (.) character to be used in property names, as pointed in vostok/logging.formatting#9 