### PR TITLE
Speed up Info\Error\etc extensions by ~10-20 percent. 

### DIFF
--- a/Vostok.Logging.Abstractions.Tests/LogExtensions_Benchmarks.cs
+++ b/Vostok.Logging.Abstractions.Tests/LogExtensions_Benchmarks.cs
@@ -1,0 +1,80 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Running;
+using NUnit.Framework;
+
+namespace Vostok.Logging.Abstractions.Tests
+{
+    [Explicit]
+    public class LogExtensions_Benchmarks
+    {
+        private ILog log;
+
+        [Test]
+        public void RunBenchmark()
+        {
+            BenchmarkRunner.Run<LogExtensions_Benchmarks>(
+                DefaultConfig.Instance
+                    .AddDiagnoser(MemoryDiagnoser.Default)
+                    .WithOption(ConfigOptions.DisableOptimizationsValidator, true));
+        }
+
+        [GlobalSetup]
+        public void SetUp()
+        {
+            log = new DevNullLog();
+        }
+
+        [Benchmark(Baseline = true)]
+        public void WithTwoParameters()
+        {
+            log.Info("xxx = {one} yyy = {two}.", "125", "qqq");
+        }
+
+        [Benchmark]
+        public void WithFourParameters()
+        {
+            log.Info("xxx = {one} yyy = {two}, zzzz = {three}, wwwwwww = {four}.", "125", "qqq", "qwerty", "42");
+        }
+
+        [Benchmark]
+        public void WithFiveParameters()
+        {
+            log.Info("xxx = {one} yyy = {two}, zzzz = {three}, wwwwwww = {four} ({five}).", "125", "qqq", "qwerty", "42", "43");
+        }
+
+        private class DevNullLog : ILog
+        {
+            private LogEvent lastEvent;
+
+            public void Log(LogEvent @event)
+            {
+                lastEvent = @event;
+            }
+
+            public bool IsEnabledFor(LogLevel level) => true;
+
+            public ILog ForContext(string context) => this;
+        }
+
+        /*
+        // * Summary*
+
+        BenchmarkDotNet = v0.13.0, OS = Windows 10.0.19043.1415 (21H1/May2021Update)
+        Intel Core i7-4771 CPU 3.50GHz(Haswell), 1 CPU, 8 logical and 4 physical cores
+        .NET SDK= 6.0.101
+
+        [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+        DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+
+
+        |             Method |     Mean |   Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+        |------------------- |---------:|--------:|---------:|------:|--------:|-------:|------:|------:|----------:|
+        |  WithTwoParameters | 319.6 ns | 6.37 ns | 14.11 ns |  1.00 |    0.00 | 0.0896 |     - |     - |     376 B |
+        | WithFourParameters | 437.4 ns | 7.86 ns |  7.36 ns |  1.32 |    0.06 | 0.1125 |     - |     - |     472 B |
+        | WithFiveParameters | 493.5 ns | 9.72 ns | 11.57 ns |  1.50 |    0.07 | 0.1297 |     - |     - |     544 B |
+
+         */
+    }
+}

--- a/Vostok.Logging.Abstractions.Tests/Vostok.Logging.Abstractions.Tests.csproj
+++ b/Vostok.Logging.Abstractions.Tests/Vostok.Logging.Abstractions.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Vostok.Logging.Abstractions/Extensions/LogEventExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/LogEventExtensions.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
+using Vostok.Commons.Collections;
 using Vostok.Logging.Abstractions.Helpers;
 using Vostok.Logging.Abstractions.Values;
 
@@ -10,6 +11,8 @@ namespace Vostok.Logging.Abstractions
     [PublicAPI]
     public static class LogEventExtensions
     {
+        private static readonly Func<string, bool> IsPositionalNameCachedFunction = IsPositionalName;
+
         [Pure]
         public static LogEvent WithObjectProperties<T>(this LogEvent @event, T @object, bool allowOverwrite = true, bool allowNullValues = true)
             => @event.MutateProperties(eventProperties => eventProperties.WithObjectProperties(@object, allowOverwrite, allowNullValues));
@@ -24,26 +27,21 @@ namespace Vostok.Logging.Abstractions
                 properties =>
                 {
                     var templatePropertyNames = TemplatePropertiesExtractor.ExtractPropertyNames(@event.MessageTemplate);
-
-                    if (ShouldInferNamesForPositionalParameters(templatePropertyNames))
-                    {
-                        // (iloktionov): Name positional parameters with corresponding placeholder names from template:
-                        for (var i = 0; i < Math.Min(parameters.Length, templatePropertyNames.Length); i++)
-                            properties = properties.Set(templatePropertyNames[i], parameters[i]);
-
-                        if (parameters.Length > templatePropertyNames.Length)
-                            for (var i = templatePropertyNames.Length; i < parameters.Length; i++)
-                                properties = properties.Set(i.ToString(), parameters[i]);
-                    }
-                    else
-                    {
-                        // (iloktionov): Name positional parameters with their indices:
-                        for (var i = 0; i < parameters.Length; i++)
-                            properties = properties.Set(i.ToString(), parameters[i]);
-                    }
-
-                    return properties;
+                    return FillImmutableArrayDictionaryWithProperties(templatePropertyNames, parameters, properties);
                 });
+        }
+
+        [Pure]
+        internal static ImmutableArrayDictionary<string, object> GenerateInitialParameters(string messageTemplate, object[] parameters)
+        {
+            if (parameters == null || parameters.Length == 0)
+                return null;
+
+            var properties = parameters.Length > 4 ? LogEvent.CreateProperties(parameters.Length) : LogEvent.CreateProperties();
+
+            var templatePropertyNames = TemplatePropertiesExtractor.ExtractPropertyNames(messageTemplate);
+
+            return FillImmutableArrayDictionaryWithProperties(templatePropertyNames, parameters, properties);
         }
 
         internal static bool HasMatchingSourceContexts(this LogEvent @event, string[] contexts)
@@ -65,12 +63,34 @@ namespace Vostok.Logging.Abstractions
                     sourceContext.Any(value => value.StartsWith(context, StringComparison.OrdinalIgnoreCase)));
         }
 
+        private static ImmutableArrayDictionary<string, object> FillImmutableArrayDictionaryWithProperties(string[] templatePropertyNames, object[] parameters, ImmutableArrayDictionary<string, object> properties)
+        {
+            if (ShouldInferNamesForPositionalParameters(templatePropertyNames))
+            {
+                // (iloktionov): Name positional parameters with corresponding placeholder names from template:
+                for (var i = 0; i < Math.Min(parameters.Length, templatePropertyNames.Length); i++)
+                    properties = properties.Set(templatePropertyNames[i], parameters[i]);
+
+                if (parameters.Length > templatePropertyNames.Length)
+                    for (var i = templatePropertyNames.Length; i < parameters.Length; i++)
+                        properties = properties.Set(i.ToString(), parameters[i]);
+            }
+            else
+            {
+                // (iloktionov): Name positional parameters with their indices:
+                for (var i = 0; i < parameters.Length; i++)
+                    properties = properties.Set(i.ToString(), parameters[i]);
+            }
+
+            return properties;
+        }
+
         private static bool ShouldInferNamesForPositionalParameters(string[] propertyNames)
         {
             if (propertyNames.Length == 0)
                 return false;
 
-            if (propertyNames.All(IsPositionalName))
+            if (propertyNames.All(IsPositionalNameCachedFunction))
                 return false;
 
             return true;

--- a/Vostok.Logging.Abstractions/Extensions/LogEventExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/LogEventExtensions.cs
@@ -24,11 +24,7 @@ namespace Vostok.Logging.Abstractions
                 return @event;
 
             return @event.MutateProperties(
-                properties =>
-                {
-                    var templatePropertyNames = TemplatePropertiesExtractor.ExtractPropertyNames(@event.MessageTemplate);
-                    return FillImmutableArrayDictionaryWithProperties(templatePropertyNames, parameters, properties);
-                });
+                properties => FillImmutableArrayDictionaryWithProperties(@event.MessageTemplate, parameters, properties));
         }
 
         [Pure]
@@ -37,11 +33,9 @@ namespace Vostok.Logging.Abstractions
             if (parameters == null || parameters.Length == 0)
                 return null;
 
-            var properties = parameters.Length > 4 ? LogEvent.CreateProperties(parameters.Length) : LogEvent.CreateProperties();
+            var properties = LogEvent.CreateProperties(Math.Max(4, parameters.Length));
 
-            var templatePropertyNames = TemplatePropertiesExtractor.ExtractPropertyNames(messageTemplate);
-
-            return FillImmutableArrayDictionaryWithProperties(templatePropertyNames, parameters, properties);
+            return FillImmutableArrayDictionaryWithProperties(messageTemplate, parameters, properties);
         }
 
         internal static bool HasMatchingSourceContexts(this LogEvent @event, string[] contexts)
@@ -63,8 +57,10 @@ namespace Vostok.Logging.Abstractions
                     sourceContext.Any(value => value.StartsWith(context, StringComparison.OrdinalIgnoreCase)));
         }
 
-        private static ImmutableArrayDictionary<string, object> FillImmutableArrayDictionaryWithProperties(string[] templatePropertyNames, object[] parameters, ImmutableArrayDictionary<string, object> properties)
+        private static ImmutableArrayDictionary<string, object> FillImmutableArrayDictionaryWithProperties(string messageTemplate, object[] parameters, ImmutableArrayDictionary<string, object> properties)
         {
+            var templatePropertyNames = TemplatePropertiesExtractor.ExtractPropertyNames(messageTemplate);
+
             if (ShouldInferNamesForPositionalParameters(templatePropertyNames))
             {
                 // (iloktionov): Name positional parameters with corresponding placeholder names from template:

--- a/Vostok.Logging.Abstractions/Extensions/LogExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/LogExtensions.cs
@@ -96,7 +96,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Debug))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Debug, PreciseDateTime.Now, messageTemplate, exception).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Debug, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), exception));
         }
 
         [Obsolete("Use the Debug(ILog, Exception, string) overload instead.")]
@@ -206,7 +206,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Info))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Info, PreciseDateTime.Now, messageTemplate, exception).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Info, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), exception));
         }
 
         [Obsolete("Use the Info(ILog, Exception, string) overload instead.")]
@@ -316,7 +316,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Warn))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Warn, PreciseDateTime.Now, messageTemplate, exception).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Warn, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), exception));
         }
 
         [Obsolete("Use the Warn(ILog, Exception, string) overload instead.")]
@@ -426,7 +426,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Error))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Error, PreciseDateTime.Now, messageTemplate, exception).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Error, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), exception));
         }
 
         [Obsolete("Use the Error(ILog, Exception, string) overload instead.")]
@@ -536,7 +536,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Fatal))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Fatal, PreciseDateTime.Now, messageTemplate, exception).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Fatal, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), exception));
         }
 
         [Obsolete("Use the Fatal(ILog, Exception, string) overload instead.")]

--- a/Vostok.Logging.Abstractions/Extensions/LogExtensions.cs
+++ b/Vostok.Logging.Abstractions/Extensions/LogExtensions.cs
@@ -68,7 +68,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Debug))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Debug, PreciseDateTime.Now, messageTemplate).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Debug, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), null));
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Info))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Info, PreciseDateTime.Now, messageTemplate).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Info, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), null));
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Warn))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Warn, PreciseDateTime.Now, messageTemplate).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Warn, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), null));
         }
 
         /// <summary>
@@ -398,7 +398,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Error))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Error, PreciseDateTime.Now, messageTemplate).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Error, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), null));
         }
 
         /// <summary>
@@ -508,7 +508,7 @@ namespace Vostok.Logging.Abstractions
             if (!log.IsEnabledFor(LogLevel.Fatal))
                 return;
 
-            log.Log(new LogEvent(LogLevel.Fatal, PreciseDateTime.Now, messageTemplate).WithParameters(parameters));
+            log.Log(new LogEvent(LogLevel.Fatal, PreciseDateTime.Now, messageTemplate, LogEventExtensions.GenerateInitialParameters(messageTemplate, parameters), null));
         }
 
         /// <summary>

--- a/Vostok.Logging.Abstractions/LogEvent.cs
+++ b/Vostok.Logging.Abstractions/LogEvent.cs
@@ -133,6 +133,14 @@ namespace Vostok.Logging.Abstractions
         public LogEvent WithTimestamp(DateTimeOffset timestamp)
             => new LogEvent(Level, timestamp, MessageTemplate, Properties, Exception);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ImmutableArrayDictionary<string, object> CreateProperties()
+            => new ImmutableArrayDictionary<string, object>(StringComparer.Ordinal);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static ImmutableArrayDictionary<string, object> CreateProperties(int capacity)
+            => new ImmutableArrayDictionary<string, object>(capacity, StringComparer.Ordinal);
+
         internal LogEvent WithProperty<T>([NotNull] string key, [CanBeNull] T value, bool allowOverwrite)
         {
             if (key == null)
@@ -165,9 +173,5 @@ namespace Vostok.Logging.Abstractions
 
             return Properties as ImmutableArrayDictionary<string, object> ?? new ImmutableArrayDictionary<string, object>(Properties, StringComparer.Ordinal);
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ImmutableArrayDictionary<string, object> CreateProperties()
-            => new ImmutableArrayDictionary<string, object>(StringComparer.Ordinal);
     }
 }


### PR DESCRIPTION
In one of my apps, log.Info is the second major consumer of time and CPU and the fifth spammer for memory traffic.
Also I have a significant number of calls to Debug and Warn extensions.

So a little refactoring to avoid unnecessary closures and delegates, as well as a little savings in rebuilding the LogEvent, speed up these extensions by up to 10-20 percent (depending on the input). And it slightly reduces the traffic of objects.

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.19043.1415 (21H1/May2021Update)
Intel Core i7-4771 CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET SDK=6.0.101
  [Host]      : .NET 5.0.13 (5.0.1321.56516), X64 RyuJIT


|                Method |     Mean |  Gen 0 | Allocated |
|---------------------- |---------:|-------:|----------:|
|     WithTwoParameters | 356.7 ns | 0.0896 |     376 B |
|  WithTwoParametersOld | 413.9 ns | 0.1431 |     600 B |


|                Method |     Mean |  Gen 0 | Allocated |
|---------------------- |---------:|-------:|----------:|
|    WithFourParameters | 488.4 ns | 0.1125 |     472 B |
| WithFourParametersOld | 544.4 ns | 0.1659 |     696 B |


|                Method |     Mean |  Gen 0 | Allocated |
|---------------------- |---------:|-------:|----------:|
|    WithFiveParameters | 551.4 ns | 0.1297 |     544 B |
| WithFiveParametersOld | 648.6 ns | 0.2289 |     960 B |