### PR TITLE
WithMutatedPropertiesLog minor improvements.

### DIFF
--- a/Vostok.Logging.Abstractions.Tests/DevNullLog.cs
+++ b/Vostok.Logging.Abstractions.Tests/DevNullLog.cs
@@ -1,0 +1,16 @@
+﻿namespace Vostok.Logging.Abstractions.Tests
+{
+    internal class DevNullLog : ILog
+    {
+        private LogEvent lastEvent;
+
+        public void Log(LogEvent @event)
+        {
+            lastEvent = @event;
+        }
+
+        public bool IsEnabledFor(LogLevel level) => true;
+
+        public ILog ForContext(string context) => this;
+    }
+}

--- a/Vostok.Logging.Abstractions.Tests/LogExtensions_Benchmarks.cs
+++ b/Vostok.Logging.Abstractions.Tests/LogExtensions_Benchmarks.cs
@@ -44,20 +44,6 @@ namespace Vostok.Logging.Abstractions.Tests
             log.Info("xxx = {one} yyy = {two}, zzzz = {three}, wwwwwww = {four} ({five}).", "125", "qqq", "qwerty", "42", "43");
         }
 
-        private class DevNullLog : ILog
-        {
-            private LogEvent lastEvent;
-
-            public void Log(LogEvent @event)
-            {
-                lastEvent = @event;
-            }
-
-            public bool IsEnabledFor(LogLevel level) => true;
-
-            public ILog ForContext(string context) => this;
-        }
-
         /*
         // * Summary*
 

--- a/Vostok.Logging.Abstractions.Tests/WithPropertyLogExtensions_Benchmarks.cs
+++ b/Vostok.Logging.Abstractions.Tests/WithPropertyLogExtensions_Benchmarks.cs
@@ -1,0 +1,60 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Running;
+using NUnit.Framework;
+
+namespace Vostok.Logging.Abstractions.Tests
+{
+    [Explicit]
+    public class WithPropertyLogExtensions_Benchmarks
+    {
+        private ILog log;
+
+        [Test]
+        public void RunBenchmark()
+        {
+            BenchmarkRunner.Run<WithPropertyLogExtensions_Benchmarks>(
+                DefaultConfig.Instance
+                    .AddDiagnoser(MemoryDiagnoser.Default)
+                    .WithOption(ConfigOptions.DisableOptimizationsValidator, true));
+        }
+
+        //For example, tracing module add two properties.
+        [Params(2)]
+        public int PropertiesCount = 2;
+
+        [GlobalSetup]
+        public void SetUp()
+        {
+            log = new DevNullLog();
+            for (int i = 0; i < PropertiesCount; i++)
+            {
+                var i1 = i;
+                log = log.WithProperty(i.ToString(), () => i1.ToString());
+            }
+        }
+
+        [Benchmark]
+        public void LogWithPropertiesOnBaseLog()
+        {
+            log.Info("Empty message");
+        }
+
+        /*
+        // * Summary *
+        
+        BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19043.1415 (21H1/May2021Update)
+        Intel Core i7-4771 CPU 3.50GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
+        .NET SDK=6.0.101
+          [Host]     : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+          DefaultJob : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
+        
+        
+        |                     Method | PropertiesCount |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
+        |--------------------------- |---------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
+        | LogWithPropertiesOnBaseLog |               2 | 266.7 ns | 2.97 ns | 2.63 ns | 0.0877 |     - |     - |     368 B |
+
+        */
+    }
+}


### PR DESCRIPTION
WithMutatedPropertiesLog spams the allocation of the Enumerator object and lambda object every `Log` call.

A simple refactoring speeds this up by ~10-13 percents (depends on input):

|                        Method | PropertiesCount |     Mean |   Error |  StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------ |---------------- |---------:|--------:|--------:|-------:|------:|------:|----------:|
| LogWithPropertiesOnBaseLogOld |               2 | 303.1 ns | 6.11 ns | 9.51 ns | 0.1125 |     - |     - |     472 B |
| LogWithPropertiesOnBaseLogNew |               2 | 266.7 ns | 2.97 ns | 2.63 ns | 0.0877 |     - |     - |     368 B |